### PR TITLE
SLING-6779 - The HTL compiler and Maven Plugin should warn when using potentially invalid options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@
         <jacoco.maven.plugin.version>0.7.9</jacoco.maven.plugin.version>
         <!-- HTL modules under test versions -->
         <org.apache.sling.scripting.sightly.runtime.version>1.1.1-1.4.0-SNAPSHOT</org.apache.sling.scripting.sightly.runtime.version>
-        <org.apache.sling.scripting.sightly.compiler.version>1.1.3-1.4.0-SNAPSHOT</org.apache.sling.scripting.sightly.compiler.version>
+        <org.apache.sling.scripting.sightly.compiler.version>1.2.0-1.4.0-SNAPSHOT</org.apache.sling.scripting.sightly.compiler.version>
         <org.apache.sling.scripting.sightly.compiler.java.version>1.1.3-1.4.0-SNAPSHOT</org.apache.sling.scripting.sightly.compiler.java.version>
-        <org.apache.sling.scripting.sightly.version>1.1.3-1.4.0-SNAPSHOT</org.apache.sling.scripting.sightly.version>
+        <org.apache.sling.scripting.sightly.version>1.2.0-1.4.0-SNAPSHOT</org.apache.sling.scripting.sightly.version>
         <org.apache.sling.scripting.sightly.js.provider.version>1.0.29-SNAPSHOT</org.apache.sling.scripting.sightly.js.provider.version>
         <org.apache.sling.scripting.sightly.models.provider.version>1.0.9-SNAPSHOT</org.apache.sling.scripting.sightly.models.provider.version>
         <org.apache.sling.scripting.sightly.testing.content.version>1.0.13-1.4.0-SNAPSHOT</org.apache.sling.scripting.sightly.testing.content.version>


### PR DESCRIPTION
* added all known expression and plugin options to the compiler
* added the possibility to configure the compiler to ignore certain additional options
* enhanced the HTL Script Engine to allow it to configure the compiler for additional options
* enhanced the HTL Maven Plugin to rely on a new configuration option to pass down additional
options to the compiler